### PR TITLE
Added mention of termguicolors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ Plug 'Mofiqul/dracula.nvim'
 
 ```lua
 -- Lua:
+vim.o.termguicolors = true
 vim.cmd[[colorscheme dracula]]
 
 ```
 ```vim
 " Vim-Script:
+let g:termguicolors = true
 colorscheme dracula
 ```
 


### PR DESCRIPTION
I've been trying to make this work for a couple of hours looking through
other folks configs who also use it, and it would never have occured to
me that this would be the fix for the it showing no colors

I've attached two images (the the PR) of how it looks with and without option set. 

`vim.o.termguicolors = false`

![bad](https://user-images.githubusercontent.com/7551358/139599800-4e605a88-cfbe-4bce-aac2-1d6f4dc89700.png)

`vim.o.termguicolors = true`

![good](https://user-images.githubusercontent.com/7551358/139599802-8e5dbfd7-bbb1-4f70-970e-9ad788987484.png)

I added the mention in the code snippet, but if you'd rather have it in a note or something, LMK

Thank you for your work
/frede