### PR TITLE
Streamline lualine theme

### DIFF
--- a/lua/lualine/themes/dracula-nvim.lua
+++ b/lua/lualine/themes/dracula-nvim.lua
@@ -1,14 +1,6 @@
 local dracula = {}
 
-local colors = {
-  black        = "#191A21",
-  white        = '#F8F8F2',
-  red          = '#FF5555',
-  green        = '#50FA7B',
-  purple       = '#BD93F9',
-  pink         = '#FF79C6',
-  yellow       = '#F1FA8C',
-}
+local colors = require('dracula').colors()
 
 dracula.normal = {
   b = {fg = colors.purple, bg = colors.black},

--- a/lua/lualine/themes/dracula-nvim.lua
+++ b/lua/lualine/themes/dracula-nvim.lua
@@ -3,8 +3,8 @@ local dracula = {}
 local colors = require('dracula').colors()
 
 dracula.normal = {
-  b = {fg = colors.purple, bg = colors.black},
   a = {fg = colors.black, bg = colors.purple, gui = 'bold'},
+  b = {fg = colors.purple, bg = colors.black},
   c = {fg = colors.white, bg = colors.black}
 }
 
@@ -14,13 +14,13 @@ dracula.visual = {
 }
 
 dracula.inactive = {
+  a = {fg = colors.white, bg = colors.gray, gui = 'bold'},
   b = {fg = colors.black, bg = colors.white},
-  a = {fg = colors.white, bg = colors.gray, gui = 'bold'}
 }
 
 dracula.replace = {
-  b = {fg = colors.yellow, bg = colors.black},
   a = {fg = colors.black, bg = colors.yellow, gui = 'bold'},
+  b = {fg = colors.yellow, bg = colors.black},
   c = {fg = colors.white, bg = colors.black}
 }
 

--- a/lua/lualine/themes/dracula-nvim.lua
+++ b/lua/lualine/themes/dracula-nvim.lua
@@ -2,15 +2,22 @@ local dracula = {}
 
 local colors = require('dracula').colors()
 
+local bg = ""
+if vim.g.dracula_lualine_bg_color ~= nil then
+    bg = vim.g.dracula_lualine_bg_color
+else
+    bg = colors.black
+end
+
 dracula.normal = {
   a = {fg = colors.black, bg = colors.purple, gui = 'bold'},
-  b = {fg = colors.purple, bg = colors.black},
-  c = {fg = colors.white, bg = colors.black}
+  b = {fg = colors.purple, bg = bg},
+  c = {fg = colors.white, bg = bg},
 }
 
 dracula.visual = {
   a = {fg = colors.black, bg = colors.pink, gui = 'bold'},
-  b = {fg = colors.pink, bg = colors.black},
+  b = {fg = colors.pink, bg = bg},
 }
 
 dracula.inactive = {
@@ -20,14 +27,14 @@ dracula.inactive = {
 
 dracula.replace = {
   a = {fg = colors.black, bg = colors.yellow, gui = 'bold'},
-  b = {fg = colors.yellow, bg = colors.black},
-  c = {fg = colors.white, bg = colors.black}
+  b = {fg = colors.yellow, bg = bg},
+  c = {fg = colors.white, bg = bg},
 }
 
 dracula.insert = {
   a = {fg = colors.black, bg = colors.green, gui = 'bold'},
-  b = {fg = colors.green, bg = colors.black},
-  c = {fg = colors.white, bg = colors.black}
+  b = {fg = colors.green, bg = bg},
+  c = {fg = colors.white, bg = bg},
 }
 
 return dracula


### PR DESCRIPTION
I thought it would be nice to use the same colors as in the main theme, so this includes them

It also allows the user to specify `g:dracula_lualine_bg_color`, and default to the black value that is currently used. I've done this because I personally use the dracula tmux theme, and it looks very strange with the black lualine against the tmux bar.

The rest is just cleanup