### PR TITLE
Added ColorColumn highlight

### DIFF
--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -117,6 +117,7 @@ M.apply = function()
 	highlight("Conceal", colors.comment, nil, nil, nil)
 	highlight("CursorColumn", nil, colors.black, nil, nil)
 	highlight("CursorLine", nil, colors.selection, nil, nil)
+	highlight("ColorColumn", nil, colors.selection, nil, nil)
 
 	highlight("StatusLine", colors.white, colors.black, nil, nil)
 	highlight("StatusLineNC", colors.comment, nil, nil, nil)


### PR DESCRIPTION
Removes the ugly default ColorColumn dark red highlight (on the right below)

![image](https://user-images.githubusercontent.com/62098008/143822488-a2f57261-3928-4bee-a965-4538d71358a1.png)
