### PR TITLE
Highlight groups changed for Tree-sitter markdown parser.

### DIFF
--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -219,15 +219,16 @@ M.apply = function()
 	highlight("TSVariable", colors.fg, nil, nil, nil)
 	highlight("TSVariableBuiltin", colors.purple, nil, nil, nil)
 
-	highlight("TSText", colors.orange, nil, nil, nil)
-	highlight("TSStrong", colors.orange, nil, nil, nil)
-	highlight("TSEmphasis", colors.orange, nil, nil, nil)
-	highlight("TSUnderline", colors.orange, nil, nil, nil)
-	highlight("TSTitle", colors.orange, nil, nil, nil)
-	highlight("TSLiteral", colors.orange, nil, nil, nil)
-	highlight("TSURI", colors.orange, nil, nil, nil)
 
-	highlight("TSTag", colors.cyan, nil, nil, nil)
+  highlight("TSText", colors.orange, nil, nil, nil)
+	highlight("TSStrong", colors.yellow, nil, "italic", nil)  -- italic
+	highlight("TSEmphasis", colors.orange, nil, "bold", nil)  -- bold
+	highlight("TSUnderline", colors.orange, nil, nil, nil)
+	highlight("TSTitle", colors.pink, nil, nil, nil)          -- title
+	highlight("TSLiteral", colors.yellow, nil, nil, nil)      -- inline code
+	highlight("TSURI", colors.yellow, nil, "italic", nil)     -- urls
+
+  highlight("TSTag", colors.cyan, nil, nil, nil)
 	highlight("TSTagDelimiter", colors.white, nil, nil, nil)
 
 	-- HTML


### PR DESCRIPTION
Changed [some](https://www.reddit.com/r/neovim/comments/rg97j4/treesitter_for_markdown/hoje1mg/?utm_source=reddit&utm_medium=web2x&context=3) highlight groups to support the tree-sitter markdown parser.