### PR TITLE
Update transparent_bg information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ let bufferline.animation = v:true
 " show the '~' characters after the end of buffers
 let g:dracula_show_end_of_buffer = 1
 " use transparent background
-let g:dracula_transparent_bg = 1
+let g:dracula_transparent_bg = v:true
 " set custom lualine background color
 let g:dracula_lualine_bg_color = "#44475a"
 -- set italic comment


### PR DESCRIPTION
This PR fixes README information regarding transparent_bg in vim setup

Also reported here:
https://github.com/Mofiqul/dracula.nvim/issues/31