### PR TITLE
fix: typo in parameter group

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -149,7 +149,7 @@ local function setup(configs)
       ['@function.builtin'] = { fg = colors.cyan, },
       ['@function'] = { fg = colors.green, },
       ['@function.macro'] = { fg = colors.green, },
-      ['@paramter'] = { fg = colors.orange, },
+      ['@parameter'] = { fg = colors.orange, },
       ['@parameter.reference'] = { fg = colors.orange, },
       ['@method'] = { fg = colors.green, },
       ['@field'] = { fg = colors.orange, },


### PR DESCRIPTION
Before:
![Screen Shot 2022-10-20 at 9 57 41 AM](https://user-images.githubusercontent.com/10931469/196984636-d074320c-1d13-4452-bf82-0edf679aa17e.png)

After:
![Screen Shot 2022-10-20 at 9 57 23 AM](https://user-images.githubusercontent.com/10931469/196984681-d793efd0-65ed-4813-9ef4-584048591e85.png)
