### PR TITLE
#53 (docs): update Readme, neovim version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## ✔️ Requirements
 
-- Neovim >= 0.7.0
+- Neovim >= 0.8.0
 - Treesitter (optional)
 
 ## #️ Supported Plugins


### PR DESCRIPTION
* Changed Neovim requirement version to 0.8 in order to avoid W18: Invalid character in group name errors.