### PR TITLE
Add BufferLineBufferSelected for Bufferline Plugin

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -290,6 +290,7 @@ local function setup(configs)
       -- Bufferline
       BufferLineIndicatorSelected = { fg = colors.purple, },
       BufferLineFill = { bg = colors.black, },
+      BufferLineBufferSelected = { bg = colors.bg, },
 
       -- LSP
       DiagnosticError = { fg = colors.red, },


### PR DESCRIPTION
There is an issue where the Selected buffer background is white, this PR aims to solve it.

Before:
![Screen Shot 2022-12-04 at 16 08 32](https://user-images.githubusercontent.com/1410462/205498530-4aa72e15-fbc8-466a-aa48-f8462de0d2fd.png)

After:
![Screen Shot 2022-12-04 at 16 09 51](https://user-images.githubusercontent.com/1410462/205498582-570fd80e-da40-40d9-8880-07be8c901ba0.png)

