### PR TITLE
Added `@type.qualifier` highlight

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -167,6 +167,7 @@ local function setup(configs)
       ['@exception'] = { fg = colors.purple, },
       ['@type'] = { fg = colors.bright_cyan, },
       ['@type.builtin'] = { fg = colors.cyan, italic = true, },
+      ['@type.qualifier'] = { fg = colors.pink, },
       ['@structure'] = { fg = colors.purple, },
       ['@include'] = { fg = colors.pink, },
 


### PR DESCRIPTION
Makes qualifiers like c++ `virtual` pink like they used to be