### PR TITLE
Add highlighting for @symbol

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -133,6 +133,7 @@ local function setup(configs)
 
       ['@constant'] = { fg = colors.purple, },
       ['@constant.builtin'] = { fg = colors.purple, },
+      ['@symbol'] = { fg = colors.purple },
 
       ['@constant.macro'] = { fg = colors.cyan, },
       ['@string.regex'] = { fg = colors.red, },


### PR DESCRIPTION
Ruby symbols aren't highlighted otherwise (when using TS)

Before:
![image](https://user-images.githubusercontent.com/9031589/208776273-b2f5b326-c846-4a40-9a1b-db2c079b6d37.png)

After:
![image](https://user-images.githubusercontent.com/9031589/208776368-ab8c35de-9020-426a-af7d-a2f71f98ce03.png)
