### PR TITLE
Change `@property` highlighting (fix #66)

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -133,7 +133,7 @@ local function setup(configs)
 
       ['@constant'] = { fg = colors.purple, },
       ['@constant.builtin'] = { fg = colors.purple, },
-      ['@symbol'] = { fg = colors.purple },
+      ['@symbol'] = { fg = colors.purple, },
 
       ['@constant.macro'] = { fg = colors.cyan, },
       ['@string.regex'] = { fg = colors.red, },
@@ -154,7 +154,7 @@ local function setup(configs)
       ['@parameter.reference'] = { fg = colors.orange, },
       ['@method'] = { fg = colors.green, },
       ['@field'] = { fg = colors.orange, },
-      ['@property'] = { fg = colors.fg, },
+      ['@property'] = { fg = colors.purple, },
       ['@constructor'] = { fg = colors.cyan, },
 
       ['@conditional'] = { fg = colors.pink, },


### PR DESCRIPTION
Changes highlighting for `@property`. This adds a bit more of highlighting to CSS files when using Treesitter (which fixes #66)

Using Treesitter on CSS file, before:
![image](https://user-images.githubusercontent.com/9031589/209010952-ae971409-a22a-4da2-b32f-040561a544be.png)

Using Treesitter on CSS file, after:
![image](https://user-images.githubusercontent.com/9031589/209011045-a5674ef6-c13f-4db7-a915-f3006b4ba871.png)

Still isn't awesome: the selectors are using the same highlighting as the CSS properties... But this is coming from Treesitter itself (which is assigning `@property` to both the selector and css properties). I tried to check a few themes on the wild and every theme I checked has the same "problem" when using Treesitter.