### PR TITLE
Change some TreeSitter highlights with markdown in mind

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -129,7 +129,7 @@ local function setup(configs)
       ['@error'] = { fg = colors.bright_red, },
       ['@punctuation.delimiter'] = { fg = colors.fg, },
       ['@punctuation.bracket'] = { fg = colors.fg, },
-      ['@punctuation.special'] = { fg = colors.fg, },
+      ['@punctuation.special'] = { fg = colors.cyan, },
 
       ['@constant'] = { fg = colors.purple, },
       ['@constant.builtin'] = { fg = colors.purple, },
@@ -179,9 +179,10 @@ local function setup(configs)
       ['@text.strong'] = { fg = colors.orange, bold = true, }, -- bold
       ['@text.emphasis'] = { fg = colors.yellow, italic = true, }, -- italic
       ['@text.underline'] = { fg = colors.orange, },
-      ['@text.title'] = { fg = colors.pink, }, -- title
+      ['@text.title'] = { fg = colors.pink, bold = true, }, -- title
       ['@text.literal'] = { fg = colors.yellow, }, -- inline code
       ['@text.uri'] = { fg = colors.yellow, italic = true, }, -- urls
+      ['@text.reference'] = { fg = colors.orange, bold = true, },
 
       ['@tag'] = { fg = colors.cyan, },
       ['@tag.attribute'] = { fg = colors.green, },


### PR DESCRIPTION
Currently I think markdown without TreeSitter looks better than with it due to the extra styling. This changes the relevant highlighting groups to make markdown with TreeSitter look more like it does without, allowing you to benefit from the other features of TreeSitter e.g. correctly highlighted code blocks. This also adds the missing @text.reference highlight group that the markdown parser uses.

Specifically:
* make titles bold
* make special punctuation (*, -, #, numbers etc) cyan. Hashtags are in the same group as the others so, to my knowledge, can't be styled a different colour unlike the No TreeSitter styling
* add references (orange and bold). The colour can be changed but I think orange contrasts the yellow links well.

Current highlighting without TreeSitter
![NoTS](https://user-images.githubusercontent.com/47077648/213264456-655dfbef-470b-44d8-961f-b1fec64d01f7.png)

Current highlighting with TreeSitter
![Current](https://user-images.githubusercontent.com/47077648/213264544-83f636c7-e014-4726-a52b-90c96658614f.png)

New highlighting with TreeSitter
![New](https://user-images.githubusercontent.com/47077648/213264591-008aada1-7436-49fd-bb49-71cfc949d8ab.png)
