### PR TITLE
[feat] add LspCodelens highlighting

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -340,6 +340,7 @@ local function setup(configs)
       LspReferenceText = { fg = colors.orange, },
       LspReferenceRead = { fg = colors.orange, },
       LspReferenceWrite = { fg = colors.orange, },
+      LspCodeLens = { fg = colors.cyan, },
 
       --LSP Saga
       LspFloatWinNormal = { fg = colors.fg, },


### PR DESCRIPTION
This adds highlighting for the `LspCodelens` highlight group. I propose to colour it the same way that Diagnostic Hints are coloured, similarly to how it has been done [here](https://github.com/marko-cerovac/material.nvim/pull/144). 