### PR TITLE
Fix ruby highlighting (Treesitter)

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -162,7 +162,7 @@ local function setup(configs)
       ['@label'] = { fg = colors.cyan, },
 
       ['@keyword'] = { fg = colors.pink, },
-      ['@keyword.function'] = { fg = colors.cyan, },
+      ['@keyword.function'] = { fg = colors.pink, },
       ['@keyword.operator'] = { fg = colors.pink, },
       ['@operator'] = { fg = colors.pink, },
       ['@exception'] = { fg = colors.purple, },


### PR DESCRIPTION
NOTE: this PR is a fix for TS master branch - the latest TS release (v0.8.5.2) is still working fine. This PR should probably not be merged before a next stable version is released on TS side.

---
Since nvim-treesitter/nvim-treesitter#4382, TS uses `@keyword.function` (instead of the previously used `@keyword`) for the ruby `def` keyword.

This PR aims to fix the ruby highlighting.

Before:
![image](https://user-images.githubusercontent.com/9031589/223401156-639cea68-135c-4f7e-82be-65587ebd2885.png)

After:
![image](https://user-images.githubusercontent.com/9031589/223401197-f87a5b07-ccee-46a2-a2e3-99bbea28bc16.png)
