### PR TITLE
feat(theme): introduce 'dracula-soft' palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,15 @@ Plug 'Mofiqul/dracula.nvim'
 ```lua
 -- Lua:
 vim.cmd[[colorscheme dracula]]
+-- or
+vim.cmd[[colorscheme dracula-soft]]
 ```
 
 ```vim
 " Vim-Script:
 colorscheme dracula
+" or:
+colorscheme dracula-soft
 ```
 
 If you are using [`lualine`](https://github.com/hoob3rt/lualine.nvim), you can also enable the provided theme:
@@ -70,8 +74,9 @@ require('lualine').setup {
 ## 🔧 Configuration
 
 The configuration must be run before `colorscheme` command to take effect.
+To customize the 'dracula-soft' variant, include `theme = 'dracula-soft'` in the `setup()` table below.
 
-If you're using lua
+If you're using Lua:
 
 ```lua
 local dracula = require("dracula")
@@ -119,7 +124,7 @@ dracula.setup({
 })
 ```
 
-The same works in viml
+The same works in Vim script:
 
 ```vim
 lua << EOF
@@ -175,6 +180,6 @@ EOF
 local colors = require('dracula').colors()
 ```
 
-This will return the folowing table
+This will return the following table (`dracula` palette shown):
 
 ![colors](./assets/colors.png)

--- a/colors/dracula-soft.lua
+++ b/colors/dracula-soft.lua
@@ -1,0 +1,1 @@
+require("dracula").load('dracula-soft')

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -10,6 +10,7 @@ local tbl_deep_extend = vim.tbl_deep_extend
 ---@field show_end_of_buffer boolean
 ---@field lualine_bg_color string?
 ---@field colors Palette
+---@field theme string?
 ---@field overrides table<string, Highlight>
 local DEFAULT_CONFIG = {
    italic_comment = false,
@@ -18,6 +19,7 @@ local DEFAULT_CONFIG = {
    lualine_bg_color = nil,
    colors = require("dracula.palette"),
    overrides = {},
+   theme = 'dracula'
 }
 
 local TRANSPARENTS = {
@@ -79,11 +81,17 @@ local local_configs = DEFAULT_CONFIG
 local function setup(configs)
    if type(configs) == "table" then
       local_configs = tbl_deep_extend("force", DEFAULT_CONFIG, configs) --[[@as DefaultConfig]]
+      if configs.theme == 'dracula-soft' then
+         print('Setting theme field to dracula-soft')
+         local_configs.colors = require('dracula.palette-soft')
+         print(local_configs)
+      end
    end
 end
 
 ---load dracula colorscheme
-local function load()
+--@param theme string?
+local function load(theme)
    if vim.version().minor < 7 then
       vim.notify_once("dracula.nvim: you must use neovim 0.7 or higher")
       return
@@ -100,7 +108,12 @@ local function load()
 
    o.background = "dark"
    o.termguicolors = true
-   g.colors_name = "dracula"
+   g.colors_name = theme or 'dracula'
+
+   if g.colors_name == 'dracula-soft' then
+      local_configs.theme = 'dracula-soft'
+      local_configs.colors = require('dracula.palette-soft')
+   end
 
    apply(local_configs)
 end

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -80,12 +80,11 @@ local local_configs = DEFAULT_CONFIG
 ---@param configs DefaultConfig?
 local function setup(configs)
    if type(configs) == "table" then
-      local_configs = tbl_deep_extend("force", DEFAULT_CONFIG, configs) --[[@as DefaultConfig]]
-      if configs.theme == 'dracula-soft' then
-         print('Setting theme field to dracula-soft')
-         local_configs.colors = require('dracula.palette-soft')
-         print(local_configs)
+      if configs.theme == "dracula-soft" then
+         -- set dracula-soft palette before merging any `configs.color` user overrides to it
+         DEFAULT_CONFIG.colors = require("dracula.palette-soft")
       end
+      local_configs = tbl_deep_extend("force", DEFAULT_CONFIG, configs) --[[@as DefaultConfig]]
    end
 end
 

--- a/lua/dracula/palette-soft.lua
+++ b/lua/dracula/palette-soft.lua
@@ -1,0 +1,30 @@
+---@class Palette
+return {
+   bg = "#292A35", --
+   fg = "#F6F6F5",
+   selection = "#7C7F8A",
+   comment = "#70747f",
+   orange = "#FDC38E",
+   -- ANSI
+   black = "#1C1C1C", -- ANSI 0
+   red = "#DD6E6B",
+   green = "#87E58E",
+   yellow = "#E8EDA2",
+   purple = "#BAA0E8", -- used as ANSI 4 (blue)
+   pink = "#E48CC1",
+   cyan = "#A7DFEF",
+   white = "#F6F6F5", -- ANSI 7, 'selection' used for ANSI 8
+   -- indexes 9-15
+   bright_red = "#E1837F",
+   bright_green = "#97EDA2",
+   bright_yellow = "#F6F6B6",
+   bright_blue = "#D0B5F3",
+   bright_magenta = "#E7A1D7",
+   bright_cyan = "#BCF4F5",
+   bright_white = "#FFFFFF", -- index 15
+
+   menu = "#21222C",
+   visual = "#3E4452",
+   gutter_fg = "#4B5263",
+   nontext = "#3B4048",
+}


### PR DESCRIPTION
Introduces the 'soft' variant of the Dracula theme from VS Code.

The VS Code 'Dracula Soft' variant is not hardcoded values, it's calculated
by reducing the main colors' saturation by 20% in [transformSoft](https://github.com/dracula/visual-studio-code/blob/master/scripts/generate.js
).

I compared the ANSI colours in :term to the ANSI colours in VS Code terminal
to make sure they match there.

Left is wezterm with `:colorscheme dracula-soft` and right is vs code with theme Dracula Soft:

<img width="1919" alt="Screen Shot 2023-03-07 at 1 23 34 PM" src="https://user-images.githubusercontent.com/7416158/223514973-260392e2-00ea-41f7-8616-28e1e77a19ea.png">

