### PR TITLE
Improve barbar highlight

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -365,10 +365,17 @@ local function setup(configs)
       CmpItemAbbrDeprecated = { fg = colors.white, bg = colors.menu, },
       CmpItemAbbrMatch = { fg = colors.cyan, bg = colors.menu, },
 
-      --barbar
-      BufferCurrentTarget = { fg = colors.red, },
-      BufferVisibleTarget = { fg = colors.red, },
-      BufferInactiveTarget = { fg = colors.red, },
+      -- barbar
+      BufferVisibleTarget = { fg = colors.red },
+      BufferTabpages = { fg = colors.nontext, bg = colors.black, bold = true },
+      BufferTabpageFill = { fg = colors.nontext, bg = colors.black },
+      BufferCurrentSign = { fg = colors.purple },
+      BufferCurrentTarget = { fg = colors.red },
+      BufferInactive = { fg = colors.comment, bg = colors.black, italic = true },
+      BufferInactiveIndex = { fg = colors.nontext, bg = colors.black, italic = true },
+      BufferInactiveMod = { fg = colors.yellow, bg = colors.black, italic = true },
+      BufferInactiveSign = { fg = colors.nontext, bg = colors.black, italic = true },
+      BufferInactiveTarget = { fg = colors.red, bg = colors.black, bold = true },
 
       -- Compe
       CompeDocumentation = { link = "Pmenu" },


### PR DESCRIPTION
This PR improves barbar highlight so that it makes the current tab more obvious. This matches the bufferline.nvim theme shipped in lunarvim. I have been using it for a while and it should be stable.

Before:
<img width="713" alt="Screenshot 2023-03-29 at 11 23 10 AM" src="https://user-images.githubusercontent.com/576382/228634235-fe8145d7-1451-4ab6-b2d6-6cf70b0b8571.png">


After:
<img width="662" alt="Screenshot 2023-03-29 at 11 28 59 AM" src="https://user-images.githubusercontent.com/576382/228634165-edec86c3-3648-496c-ad55-a23a55609590.png">
