### PR TITLE
Add BufferLineSeparator for Bufferline Plugin

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -325,6 +325,7 @@ local function setup(configs)
       BufferLineIndicatorSelected = { fg = colors.purple, },
       BufferLineFill = { bg = colors.black, },
       BufferLineBufferSelected = { bg = colors.bg, },
+      BufferLineSeparator = { fg = colors.black },
 
       -- LSP
       DiagnosticError = { fg = colors.red, },


### PR DESCRIPTION
There is a gap between the separator and the selected buffer, and this PR aims to solve it.

There is a similar issue here.
https://www.reddit.com/r/neovim/comments/14mzaps/bufferline_plugin_help/

Before:
![image](https://github.com/Mofiqul/dracula.nvim/assets/93901409/92eed98f-0da3-49eb-8d15-ac4532e5997b)

After:
![image](https://github.com/Mofiqul/dracula.nvim/assets/93901409/b5119213-fa12-4346-b850-72210d8a37c6)

![image](https://github.com/Mofiqul/dracula.nvim/assets/93901409/5b96b736-9415-4092-9783-8cce27729855)