### PR TITLE
feat(notify highlights): add missing notify highlights that go along …

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -501,6 +501,17 @@ local function setup(configs)
       DapUIBreakpointsCurrentLine = { fg = colors.bright_green, bold = true },
       DapStoppedLine = { default = true, link = 'Visual' },
       DapUIWinSelect = { fg = colors.bright_cyan, bold = true },
+
+      -- Notify
+      NotifyInfoIcon = { fg = colors().green },
+      NotifyInfoTitle = { fg = colors().green },
+      NotifyInfoBorder = { fg = "#2C453F" },
+      NotifyErrorIcon = { fg = colors().red },
+      NotifyErrorTitle = { fg = colors().red },
+      NotifyErrorBorder = { fg = "#DD6E6B" },
+      NotifyWarnIcon = { fg = colors().orange },
+      NotifyWarnTitle = { fg = colors().orange },
+      NotifyWarnBorder = { fg = "#785637" },
    }
 end
 


### PR DESCRIPTION
This PR contains missing highlights for [nvim-notify](https://github.com/rcarriga/nvim-notify)

<h1>Before</h1>

![BeforeNotify](https://github.com/Mofiqul/dracula.nvim/assets/98118238/346322e5-53ae-49ee-b5bb-f424889af0c6)

<h1>After</h1>

![AfterNotify](https://github.com/Mofiqul/dracula.nvim/assets/98118238/506b1edb-57ee-4596-9164-53a6ff1ce902)
