### PR TITLE
feat(telescope gitsigns): add telescope missing gitsigns highlights

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -291,6 +291,9 @@ local function setup(configs)
       TelescopeNormal = { fg = colors.fg, bg = colors.bg, },
       TelescopeMatching = { fg = colors.green, },
       TelescopePromptPrefix = { fg = colors.purple, },
+      TelescopeResultsDiffDelete = { fg = colors.red },
+      TelescopeResultsDiffChange = { fg = colors.cyan },
+      TelescopeResultsDiffAdd = { fg = colors.green },
 
       -- NvimTree
       NvimTreeNormal = { fg = colors.fg, bg = colors.menu, },


### PR DESCRIPTION
Missing gitsign highlights on telescope.

<h3>Before</h3>

![TelescopeResult-Before](https://github.com/Mofiqul/dracula.nvim/assets/98118238/e3d6405b-594c-4aaf-aaac-148c0c797636)

<h3>After</h3>

![TelescopeResult-After](https://github.com/Mofiqul/dracula.nvim/assets/98118238/ccaf63bb-4025-4b1e-a387-81757f5f3044)
