### PR TITLE
Change debugPc to a background color

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -270,7 +270,7 @@ local function setup(configs)
       diffNewFile = { fg = colors.green, },
       diffOldFile = { fg = colors.red, },
 
-      debugPc = { bg = colors.cyan, },
+      debugPc = { bg = colors.menu, },
       debugBreakpoint = { fg = colors.red, reverse = true, },
 
       -- Git Signs


### PR DESCRIPTION
This was cyan background before, which made it very hard to read. See screenshots

![old](https://github.com/Mofiqul/dracula.nvim/assets/7551358/6b914443-e48b-4281-8616-ee45a9ad49d6)
![new](https://github.com/Mofiqul/dracula.nvim/assets/7551358/7ce1aa7f-47f4-4777-9223-64dbeb281c65)
