### PR TITLE
feat: support for nvimdev/dashboard-nvim

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -480,6 +480,15 @@ local function setup(configs)
       AlphaShortcut = { fg = colors.orange },
       AlphaFooter = { fg = colors.purple, italic = true },
 
+      -- nvimdev/dashboard-nvim
+      DashboardShortCut = { fg = colors.cyan },
+      DashboardHeader = { fg = colors.purple },
+      DashboardCenter = { fg = colors.fg },
+      DashboardFooter = { fg = colors.purple, italic = true },
+      DashboardKey = { fg = colors.orange },
+      DashboardDesc = { fg = colors.cyan },
+      DashboardIcon = { fg = colors.cyan, bold = true },
+
       -- dap UI
       DapUIPlayPause = { fg = colors.bright_green },
       DapUIRestart = { fg = colors.green },


### PR DESCRIPTION
<img width="569" alt="image" src="https://github.com/Mofiqul/dracula.nvim/assets/55065107/4f5de69d-8370-4f6e-ba5b-a1779d445d6d">

Lazyvim changed in Version 10 from alpha to [nvimdev/dashboard-nvim](https://github.com/nvimdev/dashboard-nvim).

The colors were selected analogous to PR #88 