### PR TITLE
fix: use older methods to check for an incompatible version

### DIFF
--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -121,8 +121,8 @@ end
 ---load dracula colorscheme
 ---@param theme string?
 local function load(theme)
-   if vim.version().minor < 7 then
-      vim.api.nvim_err_writeln("dracula.nvim: you must use neovim 0.7 or higher")
+   if vim.fn.has('nvim-0.7') ~= 1 then
+      vim.notify("dracula.nvim: you must use neovim 0.7 or higher")
       return
    end
 

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -121,7 +121,7 @@ end
 ---load dracula colorscheme
 ---@param theme string?
 local function load(theme)
-   if vim.fn.has('nvim-0.7') ~= 1 then
+   if vim.fn.has("nvim-0.7") ~= 1 then
       vim.notify("dracula.nvim: you must use neovim 0.7 or higher")
       return
    end

--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -122,7 +122,7 @@ end
 ---@param theme string?
 local function load(theme)
    if vim.version().minor < 7 then
-      vim.notify_once("dracula.nvim: you must use neovim 0.7 or higher")
+      vim.api.nvim_err_writeln("dracula.nvim: you must use neovim 0.7 or higher")
       return
    end
 


### PR DESCRIPTION
`vim.version()` was introduced in neovim v0.9, and `vim.notify_once()` was introduced on v0.7, so for users on outdated versions (<v0.7), the version check errors out instead of sending a notification 

i believe the most common outdated version is the v0.6 version that ubuntu/debian/etc. has. using `vim.fn.has()` and `vim.notify()` (available since v0.5) should be enough?