### PR TITLE
Add back symbol highlighting

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -142,6 +142,7 @@ local function setup(configs)
       ['@string.regexp'] = { fg = colors.red, },
       ['@string'] = { fg = colors.yellow, },
       ['@string.escape'] = { fg = colors.cyan, },
+      ['@string.special.symbol'] = { fg = colors.purple, },
       ['@character'] = { fg = colors.green, },
       ['@number'] = { fg = colors.purple, },
       ['@boolean'] = { fg = colors.purple, },


### PR DESCRIPTION
I guess [supporting TS >0.9.2](https://github.com/Mofiqul/dracula.nvim/pull/123) broke symbol highlighting, which was added on #69.

This PR should have it added back.

Before (ruby):
![Screenshot 2024-02-23 at 13 40 00](https://github.com/Mofiqul/dracula.nvim/assets/9031589/3a26e2c7-d704-450d-adaf-9a600378f923)

After (ruby):
![Screenshot 2024-02-23 at 13 39 11](https://github.com/Mofiqul/dracula.nvim/assets/9031589/d721f6ae-b157-4631-af09-548a7116b56f)
