### PR TITLE
feat: add support for mini.icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ NOTICE: if you use an older version of neovim (>=0.8.0 <0.9.2), you can pin this
 - [indent-blankline](https://github.com/lukas-reineke/indent-blankline.nvim)
 - [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)
 - [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui)
+- [mini.indentcope](https://github.com/echasnovski/mini.indentcope)
+- [mini.icons](https://github.com/echasnovski/mini.icons)
 
 ## ⬇️ Installation
 
@@ -74,7 +76,7 @@ require('lualine').setup {
 ```
 
 If you are using [LazyVim](https://github.com/LazyVim/LazyVim), you can add this to your plugins/colorscheme.lua file:
-```
+```lua
 return {
   -- add dracula
   { "Mofiqul/dracula.nvim" },

--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -493,6 +493,16 @@ local function setup(configs)
       MiniIndentscopeSymbol = { fg = "#B5629B" },
       MiniIndentscopeSymbolOff = { fg = "#B5629B" },
 
+      -- mini.icons
+      MiniIconsAzure = { fg = colors.bright_cyan },
+      MiniIconsBlue = { fg = colors.bright_blue },
+      MiniIconsCyan = { fg = colors.cyan },
+      MiniIconsGrey = { fg = colors.white },
+      MiniIconsOrange = { fg = colors.orange },
+      MiniIconsPurple = { fg = colors.purple },
+      MiniIconsRed = { fg = colors.red },
+      MiniIconsYellow = { fg = colors.yellow },
+
 
       -- goolord/alpha-nvim
       AlphaHeader = { fg = colors.purple },


### PR DESCRIPTION
Added support for a new, seemingly quite popular plugin, mini.icons.

I've tried to keep the originally defined colors as close as possible, but of course with the Dracula hues :-)

mini.icons defines these highlight groups:\
https://github.com/echasnovski/mini.icons/blob/6fc6877d58635a13efca456cb025f1dfbf59786d/doc/mini-icons.txt#L130

I also added a link to mini.indentscope, which was already supported :-)