### PR TITLE
fix: annotate setup fields as optional

### DIFF
--- a/lua/dracula/init.lua
+++ b/lua/dracula/init.lua
@@ -5,13 +5,13 @@ local nvim_set_hl = vim.api.nvim_set_hl
 local tbl_deep_extend = vim.tbl_deep_extend
 
 ---@class DraculaConfig
----@field italic_comment boolean
----@field transparent_bg boolean
----@field show_end_of_buffer boolean
----@field lualine_bg_color string?
----@field colors Palette
----@field theme string?
----@field overrides HighlightGroups | fun(colors: Palette): HighlightGroups
+---@field italic_comment? boolean
+---@field transparent_bg? boolean
+---@field show_end_of_buffer? boolean
+---@field lualine_bg_color? string?
+---@field colors? Palette
+---@field theme? string?
+---@field overrides? HighlightGroups | fun(colors: Palette): HighlightGroups
 local DEFAULT_CONFIG = {
    italic_comment = false,
    transparent_bg = false,

--- a/lua/dracula/palette-soft.lua
+++ b/lua/dracula/palette-soft.lua
@@ -1,4 +1,4 @@
----@type Palette
+---@class Palette
 return {
    bg = "#292A35", --
    fg = "#F6F6F5",

--- a/lua/dracula/palette.lua
+++ b/lua/dracula/palette.lua
@@ -1,4 +1,28 @@
 ---@class Palette
+---@field bg string
+---@field fg string
+---@field selection string
+---@field comment string
+---@field red string
+---@field orange string
+---@field yellow string
+---@field green string
+---@field purple string
+---@field cyan string
+---@field pink string
+---@field bright_red string
+---@field bright_green string
+---@field bright_yellow string
+---@field bright_blue string
+---@field bright_magenta string
+---@field bright_cyan string
+---@field bright_white string
+---@field menu string
+---@field visual string
+---@field gutter_fg string
+---@field nontext string
+---@field white string
+---@field black string
 return {
    bg = "#282A36",
    fg = "#F8F8F2",


### PR DESCRIPTION
.. to correct "Missing required fields" messages from lua_ls

additional:
    - annotate the fields that are returned from `require("dracula").colors()`

---

I have been getting "Missing required fields" messages from lua-language-server (>= 3.12.0) for table values handed to `require("dracula").setup()`.

This is an attempt to fix those missing required fields messages.

Thanks for considering my patch!