### PR TITLE
Add blink.cmp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NOTICE: if you use an older version of neovim (>=0.8.0 <0.9.2), you can pin this
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - [nvim-compe](https://github.com/hrsh7th/nvim-compe)
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+- [blink.cmp](https://github.com/Saghen/blink.cmp/)
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
 - [NeoTree](https://github.com/nvim-neo-tree/neo-tree.nvim)

--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -31,6 +31,8 @@
 ---@nodiscard
 local function setup(configs)
    local colors = configs.colors
+   assert(colors ~= nil, "Must pass colors")
+
    local endOfBuffer = {
       fg = configs.show_end_of_buffer and colors.visual or colors.bg,
    }
@@ -445,6 +447,35 @@ local function setup(configs)
       CmpItemKindConstant = { link = "@constant" },
       CmpItemKindStruct = { link = "@structure" },
       CmpItemKindTypeParameter = { link = "@variable.parameter" },
+
+      -- Blink
+      BlinkCmpLabel = { fg = colors.white, bg = colors.bg },
+      BlinkCmpLabelDeprecated = { fg = colors.white, bg = colors.bg },
+      BlinkCmpLabelMatch = { fg = colors.cyan, bg = colors.bg },
+      BlinkCmpKind = { fg = colors.white, bg = colors.bg },
+      BlinkCmpKindFunction = { link = "@function" },
+      BlinkCmpKindConstructor = { link = "@type" },
+      BlinkCmpKindVariable = { link = "@variable" },
+      BlinkCmpKindClass = { link = "@type" },
+      BlinkCmpKindInterface = { link = "@type" },
+      BlinkCmpKindModule = { link = "@module" },
+      BlinkCmpKindProperty = { link = "@property" },
+      BlinkCmpKindOperator = { link = "@operator" },
+      BlinkCmpKindReference = { link = "@variable.parameter.reference" },
+      BlinkCmpKindUnit = { link = "@variable.member" },
+      BlinkCmpKindValue = { link = "@variable.member" },
+      BlinkCmpKindField = { link = "@variable.member" },
+      BlinkCmpKindEnum = { link = "@variable.member" },
+      BlinkCmpKindKeyword = { link = "@keyword" },
+      BlinkCmpKindSnippet = { link = "@markup" },
+      BlinkCmpKindColor = { link = "DevIconCss" },
+      BlinkCmpKindFile = { link = "TSURI" },
+      BlinkCmpKindFolder = { link = "TSURI" },
+      BlinkCmpKindEvent = { link = "@constant" },
+      BlinkCmpKindEnumMember = { link = "@variable.member" },
+      BlinkCmpKindConstant = { link = "@constant" },
+      BlinkCmpKindStruct = { link = "@structure" },
+      BlinkCmpKindTypeParameter = { link = "@variable.parameter" },
 
       -- navic
       NavicIconsFile = { link = "CmpItemKindFile" },


### PR DESCRIPTION
## Description
Add support for [blink.cmp](https://github.com/Saghen/blink.cmp/)

## Changes
Adds support for the following highlight groups:
- BlinkCmpLabel 
- BlinkCmpLabelDeprecated 
- BlinkCmpLabelMatch 
- BlinkCmpKind 
- BlinkCmpKindFunction 
- BlinkCmpKindConstructor 
- BlinkCmpKindVariable 
- BlinkCmpKindClass 
- BlinkCmpKindInterface 
- BlinkCmpKindModule 
- BlinkCmpKindProperty 
- BlinkCmpKindOperator 
- BlinkCmpKindReference 
- BlinkCmpKindUnit 
- BlinkCmpKindValue 
- BlinkCmpKindField 
- BlinkCmpKindEnum 
- BlinkCmpKindKeyword 
- BlinkCmpKindSnippet 
- BlinkCmpKindColor 
- BlinkCmpKindFile 
- BlinkCmpKindFolder 
- BlinkCmpKindEvent 
- BlinkCmpKindEnumMember 
- BlinkCmpKindConstant 
- BlinkCmpKindStruct 
- BlinkCmpKindTypeParameter