### PR TITLE
Add mini.statusline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ NOTICE: if you use an older version of neovim (>=0.8.0 <0.9.2), you can pin this
 - [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui)
 - [mini.indentcope](https://github.com/echasnovski/mini.indentcope)
 - [mini.icons](https://github.com/echasnovski/mini.icons)
+- [mini.statusline](https://github.com/echasnovski/mini.statusline)
 
 ## ⬇️ Installation
 

--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -509,6 +509,16 @@ local function setup(configs)
       MiniIconsRed = { fg = colors.red },
       MiniIconsYellow = { fg = colors.yellow },
 
+      -- mini.statusline
+      MiniStatuslineModeNormal = { fg = colors.black, bg = colors.purple, bold = true },
+      MiniStatuslineModeInsert = { fg = colors.black, bg = colors.green, bold = true },
+      MiniStatuslineModeVisual = { fg = colors.black, bg = colors.pink, bold = true },
+      MiniStatuslineModeReplace = { fg = colors.black, bg = colors.yellow, bold = true },
+      MiniStatuslineModeCommand = { fg = colors.black, bg = colors.cyan, bold = true },
+      MiniStatuslineInactive = { fg = colors.fg, bg = colors.visual, bold = true },
+      MiniStatuslineDevinfo = { fg = colors.purple, bg = colors.black },
+      MiniStatuslineFilename = { fg = colors.white, bg = colors.black },
+      MiniStatuslineFileinfo = { fg = colors.purple, bg = colors.black },
 
       -- goolord/alpha-nvim
       AlphaHeader = { fg = colors.purple },


### PR DESCRIPTION
## Description
Add support for [mini.statusline](https://github.com/echasnovski/mini.statusline)

> [!Note]
> I used the current Lualine colorscheme for this, if the bar's colorscheme is supposed to be different then tell me and I'll gladly change it

## Changes
Adds support for the following highlight groups:
- MiniStatuslineModeNormal
- MiniStatuslineModeInsert
- MiniStatuslineModeVisual
- MiniStatuslineModeReplace
- MiniStatuslineModeCommand
- MiniStatuslineInactive
- MiniStatuslineDevinfo
- MiniStatuslineFilename
- MiniStatuslineFileinfo

## Images
![Neovim](https://github.com/user-attachments/assets/2d0459c2-1c3d-4a4a-983a-7ca00eed1fb0)
