### PR TITLE
mini.files highlight groups

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -551,6 +551,16 @@ local function setup(configs)
       MiniStatuslineFilename = { fg = colors.white, bg = colors.black },
       MiniStatuslineFileinfo = { fg = colors.purple, bg = colors.black },
 
+      -- mini.files
+      MiniFilesNormal = { fg = colors.fg, bg = colors.bg },
+      MiniFilesBorder = { fg = colors.purple, bg = colors.bg },
+      MiniFilesBorderModified = { },
+      MiniFilesCursorLine = { bg = colors.selection, },
+      MiniFilesDirectory = { fg = colors.fg },
+      MiniFilesFile = { fg = colors.fg },
+      MiniFilesTitle = { fg = colors.fg },
+      MiniFilesTitleFocused = { fg = colors.yellow },
+
       -- goolord/alpha-nvim
       AlphaHeader = { fg = colors.purple },
       AlphaButtons = { fg = colors.cyan },

--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -552,8 +552,8 @@ local function setup(configs)
       MiniStatuslineFileinfo = { fg = colors.purple, bg = colors.black },
 
       -- mini.files
-      MiniFilesNormal = { fg = colors.fg, bg = colors.bg },
-      MiniFilesBorder = { fg = colors.purple, bg = colors.bg },
+      MiniFilesNormal = { fg = colors.fg, bg = colors.menu },
+      MiniFilesBorder = { fg = colors.purple, bg = colors.menu },
       MiniFilesBorderModified = { },
       MiniFilesCursorLine = { bg = colors.selection, },
       MiniFilesDirectory = { fg = colors.fg },


### PR DESCRIPTION
This PR adds definitions for the [mini.files](https://github.com/echasnovski/mini.files/blob/main/lua/mini/files.lua#L88) highlight groups:

```
--- * `MiniFilesBorder` - border of regular windows.
--- * `MiniFilesBorderModified` - border of windows showing modified buffer.
--- * `MiniFilesCursorLine` - cursor line in explorer windows.
--- * `MiniFilesDirectory` - text and icon representing directory.
--- * `MiniFilesFile` - text representing file.
--- * `MiniFilesNormal` - basic foreground/background highlighting.
--- * `MiniFilesTitle` - title of regular windows.
--- * `MiniFilesTitleFocused` - title of focused window.
```