### PR TITLE
fix: Correct colors for blink.cmp completion menu

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -449,10 +449,12 @@ local function setup(configs)
       CmpItemKindTypeParameter = { link = "@variable.parameter" },
 
       -- Blink
-      BlinkCmpLabel = { fg = colors.white, bg = colors.bg },
-      BlinkCmpLabelDeprecated = { fg = colors.white, bg = colors.bg },
-      BlinkCmpLabelMatch = { fg = colors.cyan, bg = colors.bg },
-      BlinkCmpKind = { fg = colors.white, bg = colors.bg },
+      BlinkCmpLabel = { fg = colors.white, bg = colors.menu },
+      BlinkCmpLabelDeprecated = { fg = colors.white, bg = colors.menu },
+      BlinkCmpLabelMatch = { fg = colors.cyan, bg = colors.menu },
+      BlinkCmpKind = { fg = colors.white, bg = colors.menu },
+      BlinkCmpScrollBarThumb = { bg = colors.fg },
+      BlinkCmpScrollBarGutter = { bg = colors.menu },
       BlinkCmpKindFunction = { link = "@function" },
       BlinkCmpKindConstructor = { link = "@type" },
       BlinkCmpKindVariable = { link = "@variable" },


### PR DESCRIPTION
The colors for blink.cmp's completion menu are a little off

Current:
<img width="2560" height="1408" alt="before" src="https://github.com/user-attachments/assets/5b718e35-3cec-482d-b342-a993705d9fc3" />

PR:
<img width="2560" height="1408" alt="after" src="https://github.com/user-attachments/assets/782ac00a-c7ca-4b0f-9262-c0a015786878" />
