### PR TITLE
feat: add minimal snacks.nvim picker and dashboard support

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -614,6 +614,32 @@ local function setup(configs)
       NotifyWarnIcon = { fg = colors.orange },
       NotifyWarnTitle = { fg = colors.orange },
       NotifyWarnBorder = { fg = "#785637" },
+
+      -- SnacksDashboard
+      SnacksDashboardHeader = { fg = colors.purple },
+      SnacksDashboardKey = { fg = colors.orange },
+      SnacksDashboardDesc = { fg = colors.cyan },
+      SnacksDashboardIcon = { fg = colors.cyan },
+      SnacksDashboardFooter = { fg = colors.purple, italic = true },
+
+      -- SnacksPicker
+      SnacksBackdrop = { link = "FloatShadow" },
+      SnacksPickerBorder = { fg = colors.comment },
+      SnacksPickerDir = { fg = colors.fg },
+      SnacksPickerDirectory = { fg = colors.fg },
+      SnacksPickerFile = { fg = colors.fg },
+      SnacksPickerGitStatusIgnored = { fg = colors.comment },
+      SnacksPickerGitStatusModified = { fg = colors.yellow },
+      SnacksPickerGitStatusRenamed = { fg = colors.yellow },
+      SnacksPickerGitStatusStaged = { fg = colors.bright_green },
+      SnacksPickerGitStatusUnmerged = { fg = colors.orange },
+      SnacksPickerGitStatusUntracked = { fg = colors.green },
+      SnacksPickerInput = { link = "NormalFloat" },
+      SnacksPickerInputBorder = { link = "SnacksPickerBorder" },
+      SnacksPickerMatch = { fg = colors.green, italic = true },
+      SnacksPickerPathHidden = { fg = colors.comment },
+      SnacksPickerPrompt = { fg = colors.purple },
+      SnacksPickerTitle = { fg = colors.cyan, bold = true },
    }
 end
 


### PR DESCRIPTION
Add support for [snacks.nvim dashboard](https://github.com/folke/snacks.nvim/blob/bc0630e43be5699bb94dadc302c0d21615421d93/lua/snacks/dashboard.lua#L181C1-L193C2) and [snacks.nvim picker](https://github.com/folke/snacks.nvim/blob/bc0630e43be5699bb94dadc302c0d21615421d93/lua/snacks/picker/config/highlights.lua).

I was trying to keep it minimal and was mostly referring to previous plugin highlight overrides.

Before overriding colors:
<img width="1781" height="1511" alt="Screenshot 2025-09-06 at 22 42 48" src="https://github.com/user-attachments/assets/203a101c-6752-4d63-8cd0-010466d6e433" />

<img width="1781" height="1511" alt="Screenshot 2025-09-06 at 22 42 35" src="https://github.com/user-attachments/assets/3cfdb2bc-724e-4716-892c-8ca6a1992d55" />


After overriding colors:

<img width="1781" height="1511" alt="Screenshot 2025-09-06 at 22 29 07" src="https://github.com/user-attachments/assets/92259371-286d-4d9b-9096-60ceb74fae9a" />

<img width="1781" height="1511" alt="Screenshot 2025-09-06 at 22 29 29" src="https://github.com/user-attachments/assets/5da0ec13-cab0-43a8-9946-b5e0f6fc4331" />

