### PR TITLE
fix: get rid of black block in the lualine between symbols

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -84,7 +84,7 @@ local function setup(configs)
       CursorLine = { bg = colors.selection, },
       ColorColumn = { bg = colors.selection, },
 
-      StatusLine = { fg = colors.white, bg = colors.black, },
+      StatusLine = { fg = colors.white, bg = colors.selection, },
       StatusLineNC = { fg = colors.comment, },
       StatusLineTerm = { fg = colors.white, bg = colors.black, },
       StatusLineTermNC = { fg = colors.comment, },


### PR DESCRIPTION
Fixes #136.

I've also noticed this black block between the symbols.

With adding `StatusLine = { bg = colors.selection }` it matches the rest status line. Also removing bg override might be even maybe better solution, let me know if you want me to go with this option.

Before:

<img width="1781" height="729" alt="Screenshot 2025-09-07 at 12 53 03" src="https://github.com/user-attachments/assets/c98a093c-2293-444a-a347-2c42d4b06142" />

After:

<img width="1781" height="729" alt="Screenshot 2025-09-07 at 12 51 05" src="https://github.com/user-attachments/assets/c0099fa6-d5c7-4145-a643-052ebf4bd605" />

