### PR TITLE
fix: add ignored path status and get rid of black block on terminal view

### DIFF
--- a/lua/dracula/groups.lua
+++ b/lua/dracula/groups.lua
@@ -86,7 +86,7 @@ local function setup(configs)
 
       StatusLine = { fg = colors.white, bg = colors.selection, },
       StatusLineNC = { fg = colors.comment, },
-      StatusLineTerm = { fg = colors.white, bg = colors.black, },
+      StatusLineTerm = { fg = colors.white, bg = colors.selection, },
       StatusLineTermNC = { fg = colors.comment, },
 
       Directory = { fg = colors.cyan, },
@@ -638,6 +638,7 @@ local function setup(configs)
       SnacksPickerInputBorder = { link = "SnacksPickerBorder" },
       SnacksPickerMatch = { fg = colors.green, italic = true },
       SnacksPickerPathHidden = { fg = colors.comment },
+      SnacksPickerPathIgnored = { fg = colors.comment },
       SnacksPickerPrompt = { fg = colors.purple },
       SnacksPickerTitle = { fg = colors.cyan, bold = true },
    }


### PR DESCRIPTION
Recently couple issues was exposed to me, so would be nice to fix them as well:

### Terminal status line colors.block -> colors.selection:

Before:

<img width="1608" height="1148" alt="Screenshot 2025-09-09 at 20 07 16" src="https://github.com/user-attachments/assets/45b6123e-25b2-498a-8237-86a753330413" />

After:

<img width="1608" height="1148" alt="Screenshot 2025-09-09 at 20 08 28" src="https://github.com/user-attachments/assets/c398891d-648e-47a0-921f-e03c8896ec45" />

### Ignored file with Non-Text -> Comment

Before:

<img width="1608" height="1148" alt="Screenshot 2025-09-09 at 20 09 52" src="https://github.com/user-attachments/assets/3d6f89f0-eb8a-4589-a26b-d1a4f3743aa5" />

After:

<img width="1608" height="1148" alt="Screenshot 2025-09-09 at 20 10 35" src="https://github.com/user-attachments/assets/a414a281-af40-4eff-a77c-583ab583eeaf" />